### PR TITLE
当微信未被安装时，不显示

### DIFF
--- a/WeixinActivity/WeixinActivityBase.m
+++ b/WeixinActivity/WeixinActivityBase.m
@@ -22,12 +22,14 @@
 
 - (BOOL)canPerformWithActivityItems:(NSArray *)activityItems
 {
-    for (id activityItem in activityItems) {
-        if ([activityItem isKindOfClass:[UIImage class]]) {
-            return YES;
-        }
-        if ([activityItem isKindOfClass:[NSURL class]]) {
-            return YES;
+    if ([WXApi isWXAppInstalled] && [WXApi isWXAppSupportApi]) {
+        for (id activityItem in activityItems) {
+            if ([activityItem isKindOfClass:[UIImage class]]) {
+                return YES;
+            }
+            if ([activityItem isKindOfClass:[NSURL class]]) {
+                return YES;
+            }
         }
     }
     return NO;


### PR DESCRIPTION
加入判断，如果微信未被安装或者安装的版本不支持 OpenAPI，不显示。

PS：如果没有在 `didFinishLaunchingWithOptions` 中正确注册 app ID，也不会显示。
